### PR TITLE
fix: fail gracefully on unhandled promise reject

### DIFF
--- a/src/compose/compose.test.ts
+++ b/src/compose/compose.test.ts
@@ -194,4 +194,30 @@ describe(compose.name, () => {
         jest.runAllTimers()
         expect(await runner).toStrictEqual([1, 3, 2])
     })
+
+    it('should return the initial state for unhandled exceptions', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {
+            /**/
+        })
+
+        const reduce = compose<number[]>(
+            async () => {
+                await delay(100)
+                return (draft) => {
+                    draft.push(1)
+                }
+            },
+            async () => {
+                throw new Error('err')
+                return (draft) => {
+                    draft.push(2)
+                }
+            }
+        )
+
+        const initial: number[] = []
+        const runner = reduce(initial)
+        jest.runAllTimers()
+        expect(await runner).toBe(initial)
+    })
 })

--- a/src/compose/compose.ts
+++ b/src/compose/compose.ts
@@ -9,7 +9,13 @@ import {
     ThunkRecipeAsync,
 } from '~/types'
 
-import { isFunction, isAsyncFunction, immutable, watchUpdates } from '~/util'
+import {
+    isFunction,
+    isAsyncFunction,
+    immutable,
+    resolveGracefully,
+    watchUpdates,
+} from '~/util'
 
 export const compose =
     <State extends AnyObject | AnyArray, Args extends AnyArray = unknown[]>(
@@ -21,7 +27,11 @@ export const compose =
         let newState = state
         const deferred: ThunkRecipeAsync<State>[] = []
         for (const recipe of recipes) {
-            const thunk = await recipe
+            const thunk = await resolveGracefully(recipe)
+
+            if (thunk instanceof Error) {
+                return state
+            }
 
             if (thunk === undefined || !isFunction(thunk)) {
                 continue

--- a/src/compose/composeWithPatches.test.ts
+++ b/src/compose/composeWithPatches.test.ts
@@ -260,4 +260,32 @@ describe(composeWithPatches.name, () => {
             ],
         ])
     })
+
+    it('should return the initial state for unhandled exceptions', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {
+            /**/
+        })
+
+        const reduce = composeWithPatches<number[]>(
+            async () => {
+                await delay(100)
+                return (draft) => {
+                    draft.push(1)
+                }
+            },
+            async () => {
+                throw new Error('err')
+                return (draft) => {
+                    draft.push(2)
+                }
+            }
+        )
+
+        const initial: number[] = []
+        const runner = reduce(initial)
+        jest.runAllTimers()
+        const [state] = await runner
+        expect(state).toBe(initial)
+        expect(await runner).toEqual([state, [], []])
+    })
 })

--- a/src/compose/composeWithPatches.ts
+++ b/src/compose/composeWithPatches.ts
@@ -9,7 +9,13 @@ import {
     ThunkRecipeAsync,
 } from '~/types'
 
-import { isFunction, isAsyncFunction, immutable, watchUpdates } from '~/util'
+import {
+    isFunction,
+    isAsyncFunction,
+    immutable,
+    resolveGracefully,
+    watchUpdates,
+} from '~/util'
 
 export const composeWithPatches =
     <State extends AnyObject | AnyArray, Args extends AnyArray = unknown[]>(
@@ -26,7 +32,11 @@ export const composeWithPatches =
         const reversed: Patch[] = []
         const deferred: ThunkRecipeAsync<State>[] = []
         for (const recipe of recipes) {
-            const thunk = await recipe
+            const thunk = await resolveGracefully(recipe)
+
+            if (thunk instanceof Error) {
+                return [state, [], []]
+            }
 
             if (thunk === undefined || !isFunction(thunk)) {
                 continue

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,3 +1,4 @@
 export * from './is'
+export * from './promise'
 export * from './immutable'
 export * from './watchUpdates'

--- a/src/util/promise.test.ts
+++ b/src/util/promise.test.ts
@@ -1,0 +1,30 @@
+import { resolveGracefully } from './promise'
+
+describe(resolveGracefully.name, () => {
+    it('should resolve a promise', async () => {
+        const result = await resolveGracefully(Promise.resolve(1))
+        expect(result).toBe(1)
+    })
+
+    it('should resolve arbitrary input', async () => {
+        const result = await resolveGracefully(2)
+        expect(result).toBe(2)
+    })
+
+    it('should log an error message on rejection', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {
+            /**/
+        })
+        const error = new Error('oops')
+        await resolveGracefully(Promise.reject(error))
+        expect(console.error).toHaveBeenCalledWith(error)
+    })
+
+    it('should always return an explicit error object for signaling', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {
+            /**/
+        })
+        const result = await resolveGracefully(Promise.reject('error'))
+        expect(result).toEqual(expect.any(Error))
+    })
+})

--- a/src/util/promise.ts
+++ b/src/util/promise.ts
@@ -1,0 +1,5 @@
+export const resolveGracefully = <T>(maybePromise: T): Promise<T | Error> =>
+    Promise.resolve(maybePromise).catch((err) => {
+        console.error(err)
+        return new Error('__SIGNAL__')
+    })


### PR DESCRIPTION
If exceptions are not handled appropriately - compose will return the initial state regardless of any other promise resolution. It is up to developers to handle their own errors.